### PR TITLE
Corrige intervalo para aprovação

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -73,7 +73,7 @@ namespace Media4Notas
             }
 
             resultMedia = (N1 + N2 + N3 + N4) / 4;
-            if (resultMedia >= 7)
+            if (resultMedia > 6)
             {
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.WriteLine();


### PR DESCRIPTION
Dado que, aprovado seja MAIOR que 6, ou seja 6,1 até 10
A primeira condição deve ser > 6, senão, você perde o intervalo entre 6 e 7 (6.1, 6.2 ... 6.9)